### PR TITLE
Rename package name from "tsend" to "guratan"

### DIFF
--- a/.github/workflows/gh_pkg.yaml
+++ b/.github/workflows/gh_pkg.yaml
@@ -11,48 +11,48 @@ jobs:
     environment: gh_pkg
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    # .npmrc ファイルをセットアップして GitHub Packages に公開する
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '14.x'
-        registry-url: 'https://npm.pkg.github.com'
-        # デフォルトはワークフローファイルを所有するユーザまたは Organization
-        # scope: '@hankei6km'
+      # .npmrc ファイルをセットアップして GitHub Packages に公開する
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://npm.pkg.github.com'
+          # デフォルトはワークフローファイルを所有するユーザまたは Organization
+          # scope: '@hankei6km'
 
-    # https://docs.github.com/ja/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows
-    - name: Cache node modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node-modules
-      with:
-        # npm キャッシュファイルは Linux/macOS の「~/.npm」に保存される
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
+      # https://docs.github.com/ja/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm キャッシュファイルは Linux/macOS の「~/.npm」に保存される
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
 
-    # package.json を GitHub Packages 用に調整.
-    - name: Change scope
-      run: jq '.name |= (sub("^.+/"; "") | sub("^"; "@"+ (env.GITHUB_REPOSITORY | split("/")[0])  +"/")) ' package.json  > tmp_package.json && mv tmp_package.json package.json
+      # package.json を GitHub Packages 用に調整.
+      - name: Change scope
+        run: jq '.name |= (sub("^.+/"; "") | sub("^"; "@"+ (env.GITHUB_REPOSITORY | split("/")[0])  +"/")) ' package.json  > tmp_package.json && mv tmp_package.json package.json
 
-    # https://dev.classmethod.jp/articles/github-actions-npm-automatic-release/
-    # activity type を published へ変更したので念の為
-    # `publishConfig` の書き換えができたらコメント外す.
-    # - name: can-npm-publish
-    #   run: npx can-npm-publish
+      # https://dev.classmethod.jp/articles/github-actions-npm-automatic-release/
+      # activity type を published へ変更したので念の為
+      # `publishConfig` の書き換えができたらコメント外す.
+      # - name: can-npm-publish
+      #   run: npx can-npm-publish
 
-    - name: Install modules
-      run: npm ci
+      - name: Install modules
+        run: npm ci
 
-    - name: Run tests
-      run: npm run test
+      - name: Run tests
+        run: npm run test
 
-    - name: Build
-      run: npm run build
+      - name: Build
+        run: npm run build
 
-    - run: npm publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/npm_pkg.yaml
+++ b/.github/workflows/npm_pkg.yaml
@@ -12,53 +12,53 @@ jobs:
     environment: npm_pkg
 
     steps:
-    # prerelease のような文字が含まれていたら失敗させる.
-    - name: Check name and tag_name
-      if: >-
-        ${{ contains(github.event.release.name, 'p') ||
-        contains(github.event.release.tag_name, 'p') ||
-        contains(github.event.release.name, '-') ||
-        contains(github.event.release.tag_name, '-') }}
-      run: |
-        echo 'name: ${{ github.event.release.name }}'
-        echo 'tag_name: ${{ github.event.release.tag_name }}'
-        exit 1
+      # prerelease のような文字が含まれていたら失敗させる.
+      - name: Check name and tag_name
+        if: >-
+          ${{ contains(github.event.release.name, 'p') ||
+          contains(github.event.release.tag_name, 'p') ||
+          contains(github.event.release.name, '-') ||
+          contains(github.event.release.tag_name, '-') }}
+        run: |
+          echo 'name: ${{ github.event.release.name }}'
+          echo 'tag_name: ${{ github.event.release.tag_name }}'
+          exit 1
 
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    # npm に公開するように .npmrc ファイルを設定する
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '14.x'
-        registry-url: 'https://registry.npmjs.org'
+      # npm に公開するように .npmrc ファイルを設定する
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
 
-    # https://docs.github.com/ja/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows
-    - name: Cache node modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node-modules
-      with:
-        # npm キャッシュファイルは Linux/macOS の「~/.npm」に保存される
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
+      # https://docs.github.com/ja/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm キャッシュファイルは Linux/macOS の「~/.npm」に保存される
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
 
-    # https://dev.classmethod.jp/articles/github-actions-npm-automatic-release/
-    # activity type を published へ変更したので念の為
-    - name: can-npm-publish
-      run: npx can-npm-publish
+      # https://dev.classmethod.jp/articles/github-actions-npm-automatic-release/
+      # activity type を published へ変更したので念の為
+      - name: can-npm-publish
+        run: npx can-npm-publish
 
-    - name: Install modules
-      run: npm ci
+      - name: Install modules
+        run: npm ci
 
-    - name: Run tests
-      run: npm run test
+      - name: Run tests
+        run: npm run test
 
-    - name: Build
-      run: npm run build
+      - name: Build
+        run: npm run build
 
-    - run: npm publish --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,37 +7,36 @@ on:
     tags:
       - '!v*'
 jobs:
-
   jest:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-         node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    # https://docs.github.com/ja/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows
-    - name: Cache node modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node-modules
-      with:
-        # npm キャッシュファイルは Linux/macOS の「~/.npm」に保存される
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
+      # https://docs.github.com/ja/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm キャッシュファイルは Linux/macOS の「~/.npm」に保存される
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
 
-    - name: Install modules
-      run: npm install
+      - name: Install modules
+        run: npm install
 
-    - name: Run tests
-      run: npm run test
+      - name: Run tests
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# tsend
+# guratan
 
 Google Drive へファイルを送信する簡易ツール。
 
 ## Usage
 
 ```
-$ GOOGLE_APPLICATION_CREDENTIALS=./gha-creds-temp.json npx tsend send --parent-id 12345ABC --dest-file-name test.txt --src-file-name path/to/test.txt
+$ GOOGLE_APPLICATION_CREDENTIALS=./gha-creds-temp.json npx guratan send --parent-id 12345ABC --dest-file-name test.txt --src-file-name path/to/test.txt
 ```
 
 - `GOOGLE_APPLICATION_CREDENTIALS` にはサービスアカウントの鍵ファイルを指定
 - 送信先フォルダー(`--parent-id`) に同名ファイル(`--dest-file-name`) が存在するときは上書きされる
-- 各オプションは環境変数での指定も可能(例. `--parent-id` = `TSEND_PARENT_ID`)
+- 各オプションは環境変数での指定も可能(例. `--parent-id` = `GURATAN_PARENT_ID`)
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tsend",
+  "name": "guratan",
   "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "tsend",
+      "name": "guratan",
       "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
@@ -13,7 +13,7 @@
         "yargs": "^17.3.1"
       },
       "bin": {
-        "tsend": "dist/main.js"
+        "guratan": "dist/main.js"
       },
       "devDependencies": {
         "@types/jest": "^27.4.1",
@@ -2866,20 +2866,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -7810,13 +7796,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tsend",
+  "name": "guratan",
   "version": "0.1.1",
   "description": "Tiny send tool for Google Drive",
   "author": "hankei6km <hankei6km@gmail.com> (https://github.com/hankei6km)",
@@ -23,7 +23,7 @@
     "dist"
   ],
   "bin": {
-    "tsend": "dist/main.js"
+    "guratan": "dist/main.js"
   },
   "scripts": {
     "start": "npm run build && node dist/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,9 +3,9 @@ import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import { cli } from './cli.js'
 
-const envVarsPrefix = process.env['TSEND_ENV_VARS_PREFIX'] || 'TSEND'
+const envVarsPrefix = process.env['GURATAN_ENV_VARS_PREFIX'] || 'GURATAN'
 const argv = await yargs(hideBin(process.argv))
-  .scriptName('tsend')
+  .scriptName('guratan')
   .env(envVarsPrefix)
   .command(
     '$0 send [OPTIONS]',


### PR DESCRIPTION
> npm ERR! code E403
> npm ERR! 403 403 Forbidden - PUT https://registry.npmjs.org/tsend - Package name too similar to existing package send; try renaming your package to '@hankei6km/tsend' and publishing with 'npm publish --access=public' instead
> npm ERR! 403 In most cases, you or one of your dependencies are requesting
> npm ERR! 403 a package version that is forbidden by your security policy.

https://blog.npmjs.org/post/168978377570/new-package-moniker-rules
